### PR TITLE
Update for torch>1.9

### DIFF
--- a/torchfilter/filters/_extended_information_filter.py
+++ b/torchfilter/filters/_extended_information_filter.py
@@ -41,13 +41,13 @@ class ExtendedInformationFilter(KalmanFilterBase):
     @property
     def belief_covariance(self) -> types.CovarianceTorch:
         """Posterior covariance. Shape should be `(N, state_dim, state_dim)`."""
-        return fannypack.utils.cholesky_inverse(torch.cholesky(self.information_matrix))
+        return fannypack.utils.cholesky_inverse(torch.linalg.cholesky(self.information_matrix))
 
     # overrides
     @belief_covariance.setter
     def belief_covariance(self, covariance: types.CovarianceTorch):
         self.information_matrix = fannypack.utils.cholesky_inverse(
-            torch.cholesky(covariance)
+            torch.linalg.cholesky(covariance)
         )
 
     @overrides
@@ -70,7 +70,7 @@ class ExtendedInformationFilter(KalmanFilterBase):
 
         # Calculate Sigma_{t+1|t}
         pred_information_matrix = fannypack.utils.cholesky_inverse(
-            torch.cholesky(
+            torch.linalg.cholesky(
                 dynamics_A_matrix
                 @ prev_covariance
                 @ dynamics_A_matrix.transpose(-1, -2)
@@ -132,6 +132,6 @@ class ExtendedInformationFilter(KalmanFilterBase):
         self.information_matrix = information_matrix
         self.information_vector = information_vector
         self._belief_mean = (
-            fannypack.utils.cholesky_inverse(torch.cholesky(information_matrix))
+            fannypack.utils.cholesky_inverse(torch.linalg.cholesky(information_matrix))
             @ information_vector[:, :, None]
         ).squeeze(-1)

--- a/torchfilter/filters/_square_root_unscented_kalman_filter.py
+++ b/torchfilter/filters/_square_root_unscented_kalman_filter.py
@@ -54,7 +54,7 @@ class SquareRootUnscentedKalmanFilter(KalmanFilterBase):
     # overrides
     @belief_covariance.setter
     def belief_covariance(self, covariance: types.CovarianceTorch):
-        self._belief_scale_tril = torch.cholesky(covariance)
+        self._belief_scale_tril = torch.linalg.cholesky(covariance)
         self._belief_covariance = covariance
 
     @overrides
@@ -167,10 +167,10 @@ class SquareRootUnscentedKalmanFilter(KalmanFilterBase):
         # Kalman gain
         # In MATLAB:
         # > K = (P_x_k_y_k / S_y_k_pred.T) / S_y_k
-        K = torch.solve(
-            torch.solve(P_xy.transpose(-1, -2), S_y_k_pred).solution,
+        K = torch.linalg.solve(
             S_y_k_pred.transpose(-1, -2),
-        ).solution.transpose(-1, -2)
+            torch.linalg.solve(S_y_k_pred, P_xy.transpose(-1, -2)),
+        ).transpose(-1, -2)
         assert K.shape == (N, state_dim, observation_dim)
 
         # Correct mean

--- a/torchfilter/utils/_unscented_transform.py
+++ b/torchfilter/utils/_unscented_transform.py
@@ -70,7 +70,7 @@ class UnscentedTransform:
         assert input_covariance.shape == (N, dim, dim)
         assert dim == self._dim
         return self.select_sigma_points_square_root(
-            input_mean, input_scale_tril=torch.cholesky(input_covariance)
+            input_mean, input_scale_tril=torch.linalg.cholesky(input_covariance)
         )
 
     def select_sigma_points_square_root(
@@ -203,7 +203,7 @@ class UnscentedTransform:
             ],
             dim=1,
         )
-        _unused_Q, R = torch.qr(concatenated, some=False)
+        _unused_Q, R = torch.linalg.qr(concatenated, mode="complete")
         L = R[:, :dim, :].transpose(-1, -2)
         assert L.shape == (N, dim, dim)
 


### PR DESCRIPTION
`torch.solve` has been removed from newer versions of torch. A `torch.cholesky` and `torch.qr` are similarly deprecated and slated for deletion.